### PR TITLE
Non voters before first vote

### DIFF
--- a/src/view/pages/statement/components/settings/components/GetVoters.tsx
+++ b/src/view/pages/statement/components/settings/components/GetVoters.tsx
@@ -27,7 +27,9 @@ const GetVoters: FC<GetVotersProps> = ({ statementId, joinedMembers }) => {
 
 	//filter out users who haven't vote/those with no voter information
 	useEffect(() => {
-		if (voters.length > 0) {
+		if (voters.length === 0) {
+			setNonVoters(joinedMembers);
+		} else {
 			const voterIds = new Set(voters.map((voter) => voter.voter?.uid));
 			const nonVotersList = joinedMembers.filter(
 				(member) => !voterIds.has(member.uid)

--- a/src/view/pages/statement/components/settings/components/GetVoters.tsx
+++ b/src/view/pages/statement/components/settings/components/GetVoters.tsx
@@ -25,7 +25,6 @@ const GetVoters: FC<GetVotersProps> = ({ statementId, joinedMembers }) => {
 		}
 	};
 
-	//filter out users who haven't vote/those with no voter information
 	useEffect(() => {
 		if (voters.length === 0) {
 			setNonVoters(joinedMembers);


### PR DESCRIPTION
Show non voters before any voting activity occurs. Every new member is a non voter. 